### PR TITLE
Add link to data sets in Reference panel popover content

### DIFF
--- a/WebSTR/templates/view2.html
+++ b/WebSTR/templates/view2.html
@@ -329,7 +329,7 @@ initializePopover('.popover-badge');
                                     {'text': 'STR unit size', 'content': 'Size of the repeating unit of the STR', 'column': 'period'},
                                     {'text': 'Motif', 'content': 'The motif (repeat unit) of each STR is given in canonical format. The canonical repeat unit is defined as the lexicographically first repeat unit when considering all rotations and strand orientations of the repeat sequence. For example, the canonical repeat unit for the repeat sequence CAGCAGCAGCAG would be AGC. Learn more about the TRAL annotation method <a href="https://acg-team.github.io/tral/index.html" target="_blank"> here.</a>', 'column': 'motif'},
                                     {'text': '# copies (hg38)', 'content': 'The number of consecutive copies of the repeat motif present in the hg38 reference genome.', 'column': 'copies'},
-                                    {'text': 'Reference panel', 'content': 'Which repeat panel STR belongs to', 'column': 'panel'}
+                                    {'text': 'Reference panel', 'content': 'Which repeat panel STR belongs to.  Learn more about our data sets  <a href="https://webstr.ucsd.edu/about#datasets" target="_blank"> here.</a>', 'column': 'panel'}
                                 ] %}
                             {% endif %}
                             {% for header in headers %}


### PR DESCRIPTION
### Summary
PR updates popover content for the "Reference panel" column header to include a link to the data sets information page.

### Changes
- Added a link to the data sets information page in the popover content for the "Reference panel" column header.

### Testing
- Verified that the popover displays the link correctly and that it opens the specified URL in a new tab.