### PR TITLE
fixes link for exac and info about its current location

### DIFF
--- a/WebSTR/templates/about.html
+++ b/WebSTR/templates/about.html
@@ -261,7 +261,7 @@
 			<p>
 			First version of WebSTR was made by Richard Yanicky and Melissa Gymrek with input from other 
 			<a href="http://gymreklab.com/people.html">Gymrek Lab members</a>. It was originally inspired by
-			 the Exome Aggregation Database (<a href="http://www.exac.broadinstitute.org">ExAC</a>).
+			 the Exome Aggregation Database now available in the in the gnomAD browser(<a href="https://exac.broadinstitute.org/">ExAC</a>).
 			 Current version of the website, database and the API is developed in collaboration with <a href="https://github.com/acg-team">Maria Anisimova's Lab.</a>
 			</p>
 			<p>


### PR DESCRIPTION
- Previously the ExAC link was listed with an www which was removed
- ExAC broswer is no longer available at the listed site but will redirect to the [gnomAD browser](https://gnomad.broadinstitute.org/) or for [download](https://gnomad.broadinstitute.org/downloads#exac-variants)
- because the ExAC site is still up and includes the information about its move to gnomAD, I have kept it as the link with a small addition to phrasing 