### PR TITLE
moves selection metrics from hg19 to hg38

### DIFF
--- a/WebSTR/templates/downloads.html
+++ b/WebSTR/templates/downloads.html
@@ -16,6 +16,7 @@
 <li>Sinergia CRC Reference panel(gangstr_crc_hg38) <a href="https://drive.google.com/file/d/1b9zk34yIZypr_9sJRReAf0PMBaj9DWJP/view?usp=drive_link">crc_gangstr_hg38.tsv</a></li>
 <li>Sinergia CRC (gangstr_crc_hg38) Variation Data archive <a href="https://drive.google.com/file/d/1XXfbSORp06wDnVtJJVOi819FGmz5K3Xl/view?usp=drive_link">crc_gangstr_hg38_TCGA_variation.gz</a></li>
 <li>Sinergia CRC - MSI related loci in the format chromosome:start_coordinate, mapped to genes <a href="https://github.com/acg-team/webSTR-API/blob/main/notebooks/MSI_locus/MSI_related_str.csv">MSI_related_str.csv</a></li>
+<li>Per-locus selection metrics computed by SISTR:<a href="https://drive.google.com/file/d/1wo1oH7Gv8mEjCx1fbHglPJ1HChoJa89b/view?usp=sharing">SISTR results.txt</a> Read me: <a href="https://drive.google.com/file/d/1cu8Wlou9fkDXJkhfrx5TVZ1xCB6Cuq3W/view?usp=sharing">README.txt</a></li>
 </ul>
 </div>
 </div>
@@ -36,7 +37,6 @@
   <li>Mutation rate and constraint information from Gymrek et al. 2017 available for download from <a href="https://s3-us-west-2.amazonaws.com/strconstraint/Gymrek_etal_SupplementalData1_v2.bed.gz">s3://strconstraint/Gymrek_etal_SupplementalData1_v2.bed.gz</a></li>
   <li>eSTR data is based on <a href="https://drive.google.com/file/d/1eJ9Ae-4RO7kcCETmev31u3HQKCz4BpnL/view?usp=sharing">Supplementary Dataset 1</a> of Fotsing et al.</li>
   <li>Full eSTR summary statistic data: <a href="https://drive.google.com/file/d/1iqgSWJZbylVbonQ5EfWYLCn9V1CLgX5h/view?usp=sharing">eSTRGtex_DatasetS2.tar.gz</a></li>
-  <li>Per-locus selection metrics computed by SISTR:<a href="https://drive.google.com/file/d/1wo1oH7Gv8mEjCx1fbHglPJ1HChoJa89b/view?usp=sharing">SISTR results.txt</a> Read me: <a href="https://drive.google.com/file/d/1cu8Wlou9fkDXJkhfrx5TVZ1xCB6Cuq3W/view?usp=sharing">README.txt</a></li>
 </ul>
 
  <h1>Downloads previously available on strcat.teamerlich.org</h1>


### PR DESCRIPTION
- On the downloads page under data sources the item "Per-locus selection metrics computed by SISTR" has been moved out of hg19 and into the correct section under hg38